### PR TITLE
Remove unused dart:async import.

### DIFF
--- a/lib/src/package_config_handler.dart
+++ b/lib/src/package_config_handler.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.